### PR TITLE
  fix(sessions): update project_id url param to int and fix serialize…

### DIFF
--- a/services/core-api/AI_Voice_Platform/urls.py
+++ b/services/core-api/AI_Voice_Platform/urls.py
@@ -6,5 +6,4 @@ urlpatterns = [
     path('api/v1/auth/', include('accounts.urls')),
     path("api/v1/projects/", include("projects.urls")),
     path("api/v1/sessions/", include("voice_sessions.urls")),
-
 ]

--- a/services/core-api/voice_sessions/urls.py
+++ b/services/core-api/voice_sessions/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
     path('<uuid:pk>/', VoiceSessionDetailView.as_view(), name='session-detail'),
     # 3. Start a new session (Generates LiveKit Token)
     # POST /api/v1/sessions/projects/<project_id>/start/
-    path('projects/<uuid:project_id>/start/', StartSessionAPIView.as_view(), name='session-start'),
+    path('projects/<int:project_id>/start/', StartSessionAPIView.as_view(), name='session-start'),
     # 4. Finish a session (Calculate duration & update status)
     # POST /api/v1/sessions/<uuid:session_id>/finish/
     path('<uuid:session_id>/finish/', FinishSessionAPIView.as_view(), name='session-finish'),


### PR DESCRIPTION
…r read_only fields

- Changed 'project_id' in voice_sessions/urls.py from <uuid:pk> to <int:pk> to match the actual Project model ID type (fixing the 404 error).
- Added 'owner' to read_only_fields in ProjectSerializer to prevent validation errors during project creation.
- Registered 'voice_sessions' urls in the main project urls.py.

## Pull Request Title: [FEAT/FIX/CHORE]: Concise description of changes

### ⚙️ Type of Change
- [ ] Feature (New capability)
- [ ] Fix (Bug correction)
- [ ] Refactor (Code structure improvement without changing behavior)
- [ ] Chore (Dependencies, docs, CI/CD, etc.)

### 🎯 Description
A detailed explanation of the changes made and why they are necessary.

### 🧪 Testing Steps
Provide clear, step-by-step instructions on how the reviewer can test this change locally.
1. Start the server.
2. Run the endpoint: `[Endpoint URL]` with `[Method]` and `[Payload]`.
3. Verify `[Expected Result]`.

### 🔗 Related Issues
Closes #[issue-number]