### PR TITLE
 fix(sessions): update url patterns to accept integer IDs instead of …

### DIFF
--- a/services/core-api/voice_sessions/urls.py
+++ b/services/core-api/voice_sessions/urls.py
@@ -13,11 +13,11 @@ urlpatterns = [
     path('', VoiceSessionListView.as_view(), name='session-list'),
     # 2. Get specific session details
     # GET /api/v1/sessions/<uuid:pk>/
-    path('<uuid:pk>/', VoiceSessionDetailView.as_view(), name='session-detail'),
+    path('<int:pk>/', VoiceSessionDetailView.as_view(), name='session-detail'),
     # 3. Start a new session (Generates LiveKit Token)
     # POST /api/v1/sessions/projects/<project_id>/start/
     path('projects/<int:project_id>/start/', StartSessionAPIView.as_view(), name='session-start'),
     # 4. Finish a session (Calculate duration & update status)
     # POST /api/v1/sessions/<uuid:session_id>/finish/
-    path('<uuid:session_id>/finish/', FinishSessionAPIView.as_view(), name='session-finish'),
+    path('<int:session_id>/finish/', FinishSessionAPIView.as_view(), name='session-finish'),
 ]


### PR DESCRIPTION
…UUIDs

- Updated oice_sessions/urls.py to use <int:pk> and <int:session_id>.
- The previous configuration expected UUIDs, which caused 404 errors because the VoiceSession model uses standard integer IDs (e.g., 1, 2).
- This ensures the 'finish' and 'detail' endpoints are reachable.

## Pull Request Title: [FEAT/FIX/CHORE]: Concise description of changes

### ⚙️ Type of Change
- [ ] Feature (New capability)
- [ ] Fix (Bug correction)
- [ ] Refactor (Code structure improvement without changing behavior)
- [ ] Chore (Dependencies, docs, CI/CD, etc.)

### 🎯 Description
A detailed explanation of the changes made and why they are necessary.

### 🧪 Testing Steps
Provide clear, step-by-step instructions on how the reviewer can test this change locally.
1. Start the server.
2. Run the endpoint: `[Endpoint URL]` with `[Method]` and `[Payload]`.
3. Verify `[Expected Result]`.

### 🔗 Related Issues
Closes #[issue-number]