### PR TITLE
feat(frontend): integrate LiveKit voice agent demo

### DIFF
--- a/voice-frontend/src/components/HeroSection.jsx
+++ b/voice-frontend/src/components/HeroSection.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { LiveKitRoom, AudioConference } from '@livekit/components-react';
+import '@livekit/components-styles'; // Critical for audio to work!
+import { useVoiceAgent } from '../hooks/useVoiceAgent';
+
+const HeroSection = () => {
+    // Initialize the Hook
+    const { token, url, isConnected, isConnecting, error, connectToAgent, disconnect } = useVoiceAgent();
+
+    // 🔴 ACTIVE CALL VIEW (Overlay)
+    if (isConnected && token && url) {
+        return (
+            <div className="fixed inset-0 z-50 bg-black/95 flex flex-col items-center justify-center">
+                <LiveKitRoom
+                    video={false}
+                    audio={true}
+                    token={token}
+                    serverUrl={url}
+                    connect={true}
+                    data-lk-theme="default"
+                >
+                    {/* The Invisible Audio Logic */}
+                    <AudioConference />
+
+                    {/* Visual UI for the Call */}
+                    <div className="text-center">
+                        <div className="text-2xl font-bold text-white mb-4 animate-pulse">
+                            🎙️ Connected to Project Nexus
+                        </div>
+                        <p className="text-gray-400 mb-8">Go ahead, say something...</p>
+
+                        <button
+                            onClick={disconnect}
+                            className="bg-red-600 hover:bg-red-700 text-white px-8 py-3 rounded-full font-bold transition-all"
+                        >
+                            End Session
+                        </button>
+                    </div>
+                </LiveKitRoom>
+            </div>
+        );
+    }
+
+    // 🟢 NORMAL VIEW
+    return (
+        <div className="hero-section">
+            {/* ... Your existing Titles ... */}
+
+            {/* Error Message Toast */}
+            {error && (
+                <div className="bg-red-900/50 border border-red-500 text-red-200 px-4 py-2 rounded mb-4 inline-block">
+                    ⚠️ {error}
+                </div>
+            )}
+
+            <div className="flex gap-4 justify-center">
+                <button className="btn-secondary">Get API Keys</button>
+
+                <button
+                    onClick={connectToAgent}
+                    disabled={isConnecting}
+                    className="btn-primary flex items-center gap-2"
+                >
+                    {isConnecting ? (
+                        <span>🔄 Connecting...</span>
+                    ) : (
+                        <span>▶ Listen to Demo</span>
+                    )}
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default HeroSection;

--- a/voice-frontend/src/hooks/useVoiceAgent.js
+++ b/voice-frontend/src/hooks/useVoiceAgent.js
@@ -1,0 +1,75 @@
+import { useState, useCallback } from 'react';
+import api from '../api/axios'; // Imports your configured axios instance
+
+export const useVoiceAgent = () => {
+    // 1. Define State to track connection status
+    const [state, setState] = useState({
+        token: null,
+        url: null,
+        isConnected: false,
+        isConnecting: false,
+        error: null,
+    });
+
+    // 2. Function: Request a Ticket from Django
+    const connectToAgent = useCallback(async () => {
+        // Reset state before starting
+        setState(prev => ({ ...prev, isConnecting: true, error: null }));
+
+        try {
+            console.log("📡 Requesting LiveKit Token from Django...");
+
+            // This calls: http://192.168.100.30:8000/api/v1/livekit/token/
+            // The 'api' instance automatically adds your Auth Token header!
+            const response = await api.get('/livekit/token/');
+
+            console.log("✅ Token Received:", response.data);
+
+            const { token, url } = response.data;
+
+            // Update State -> This will trigger the UI to show the LiveKit Room
+            setState({
+                token,
+                url,
+                isConnected: true,
+                isConnecting: false,
+                error: null,
+            });
+
+        } catch (err) {
+            console.error("❌ Connection Failed:", err);
+
+            let errorMessage = "Failed to connect to AI Agent.";
+
+            // Handle specific errors based on the response
+            if (err.response) {
+                if (err.response.status === 401) errorMessage = "Please login to access the demo.";
+                if (err.response.status === 404) errorMessage = "Agent endpoint not found. Check Backend URL.";
+                if (err.response.status === 500) errorMessage = "Server error. Is the Docker Container running?";
+            } else if (err.request) {
+                errorMessage = "No response from server. Check your VM Network/VPN.";
+            }
+
+            setState(prev => ({
+                ...prev,
+                isConnecting: false,
+                error: errorMessage,
+            }));
+        }
+    }, []);
+
+    // 3. Function: Disconnect / Hang Up
+    const disconnect = useCallback(() => {
+        console.log("🔌 Disconnecting...");
+        setState({
+            token: null,
+            url: null,
+            isConnected: false,
+            isConnecting: false,
+            error: null,
+        });
+    }, []);
+
+    // Return everything the UI needs
+    return { ...state, connectToAgent, disconnect };
+};


### PR DESCRIPTION
- Configured `axios` interceptor to automatically attach JWT auth tokens to requests.
- Added `useVoiceAgent` hook to handle LiveKit token exchange with Django backend.
- Wired up "Listen to Demo" button in Hero section to trigger voice sessions.
- Implemented LiveKit Room overlay to visualize active AI conversations.
- Updated API base URL to point to the VM backend environment.

## Pull Request Title: [FEAT/FIX/CHORE]: Concise description of changes

### ⚙️ Type of Change
- [ ] Feature (New capability)
- [ ] Fix (Bug correction)
- [ ] Refactor (Code structure improvement without changing behavior)
- [ ] Chore (Dependencies, docs, CI/CD, etc.)

### 🎯 Description
A detailed explanation of the changes made and why they are necessary.

### 🧪 Testing Steps
Provide clear, step-by-step instructions on how the reviewer can test this change locally.
1. Start the server.
2. Run the endpoint: `[Endpoint URL]` with `[Method]` and `[Payload]`.
3. Verify `[Expected Result]`.

### 🔗 Related Issues
Closes #[issue-number]