### PR TITLE
fix(docker): resolve worker DNS timeouts and update frontend API URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,9 @@ services:
       - DB_PASSWORD=${DB_PASSWORD:-ai_voice_password}
     depends_on:
       - db
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
     networks:
       - ai-voice-network
 
@@ -30,7 +33,6 @@ services:
   # Service 2: Frontend
   # --------
   frontend:
-    #  ./services/voice-frontend
     build:
       context: ./voice-frontend
       dockerfile: Dockerfile
@@ -40,7 +42,7 @@ services:
     ports:
       - "5173:5173"
     environment:
-      - VITE_API_URL=http://192.168.100.30:8000/api/v1
+      - VITE_API_URL=http://localhost:8000/api/v1
     depends_on:
       - backend
     networks:
@@ -78,8 +80,11 @@ services:
     env_file:
       - ./services/ai-worker/.env
     restart: unless-stopped
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
     networks:
-      - ai-voice-network      # ✅ Added this so it matches other services
+      - ai-voice-network
 
 # -------
 # Networks & Volumes Definition


### PR DESCRIPTION
- Add Google DNS (8.8.8.8, 8.8.4.4) to `ai_agent` and `backend` services to resolve connection timeouts with external APIs (Deepgram/LiveKit) caused by Docker NAT networking.
- Update `VITE_API_URL` in the `frontend` service to `http://localhost:8000/api/v1` to correctly utilize port forwarding instead of a hardcoded local IP.

## Pull Request Title: [FEAT/FIX/CHORE]: Concise description of changes

### ⚙️ Type of Change
- [ ] Feature (New capability)
- [ ] Fix (Bug correction)
- [ ] Refactor (Code structure improvement without changing behavior)
- [ ] Chore (Dependencies, docs, CI/CD, etc.)

### 🎯 Description
A detailed explanation of the changes made and why they are necessary.

### 🧪 Testing Steps
Provide clear, step-by-step instructions on how the reviewer can test this change locally.
1. Start the server.
2. Run the endpoint: `[Endpoint URL]` with `[Method]` and `[Payload]`.
3. Verify `[Expected Result]`.

### 🔗 Related Issues
Closes #[issue-number]