### PR TITLE
feat(backend): implement django signals for project creation events

### DIFF
--- a/services/core-api/projects/apps.py
+++ b/services/core-api/projects/apps.py
@@ -4,3 +4,9 @@ from django.apps import AppConfig
 class ProjectsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'projects'
+
+    def ready(self):
+        # Import signals when the app is ready to ensure the receivers are registered
+        import projects.signals
+
+

--- a/services/core-api/projects/signals.py
+++ b/services/core-api/projects/signals.py
@@ -1,0 +1,42 @@
+# signals.py
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from .models import Project
+import redis
+import json
+import os
+
+# Connect to Redis
+# We retrieve the connection URL from environment variables.
+# If not set, it defaults to the internal Docker service alias 'redis'.
+redis_client = redis.Redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"))
+
+
+@receiver(post_save, sender=Project)
+def publish_project_created(sender, instance, created, **kwargs):
+    """
+    Triggered automatically after a Project model is saved to the database.
+    If a new project is created, it serializes the data and publishes it to Redis.
+    """
+    if created:
+        print(f"🚀 Signal Triggered: Project '{instance.title}' created.")
+
+        # 1. Prepare the payload (Serialize data for the frontend)
+        payload = {
+            "type": "PROJECT_CREATED",
+            "data": {
+                "id": instance.id,
+                "title": instance.title,
+                "description": instance.description,
+                "status": instance.status,
+                # Convert datetime objects to string format for JSON compatibility
+                "created_at": str(instance.created_at) if hasattr(instance, 'created_at') else ""
+            }
+        }
+
+        # 2. Publish to Redis Channel 'events:projects'
+        try:
+            redis_client.publish("events:projects", json.dumps(payload))
+            print("✅ Message published to Redis channel 'events:projects'")
+        except Exception as e:
+            print(f"❌ Failed to publish to Redis: {e}")


### PR DESCRIPTION
This commit enables the "Publisher" side of the Real-Time Event System (Milestone v0.3). We introduced a Django Signal (`post_save`) that automatically triggers whenever a new Project is created, serializing the data and publishing it to the Redis channel.

Key Changes:
- 🐍 Backend (Signals):
  - Created `services/core-api/projects/signals.py`.
  - Defined a `@receiver` for the `post_save` signal on the `Project` model.
  - Implemented JSON serialization logic to convert Project instances into a payload.
  - Added Redis publishing logic to the `events:projects` channel.

- ⚙️ App Configuration:
  - Updated `services/core-api/projects/apps.py` to register the signals on startup (`ready()` method).

-------------------------------------------------- 🧪 Manual Test Plan
--------------------------------------------------

1. Restart the Backend: $ docker-compose restart backend

2. Open Logs: $ docker logs -f nexus_backend

3. Create a Project:
   - Go to Django Admin (http://localhost:8000/admin/) and add a new project.
   - OR use the AI Voice Agent to create a project.

4. Verify Output in Logs:
   > "🚀 Signal Triggered: Project 'My New Project' created."
   > "✅ Message published to Redis channel 'events:projects'"# Please enter the commit message for your changes. Lines starting

## Pull Request Title: [FEAT/FIX/CHORE]: Concise description of changes

### ⚙️ Type of Change
- [ ] Feature (New capability)
- [ ] Fix (Bug correction)
- [ ] Refactor (Code structure improvement without changing behavior)
- [ ] Chore (Dependencies, docs, CI/CD, etc.)

### 🎯 Description
A detailed explanation of the changes made and why they are necessary.

### 🧪 Testing Steps
Provide clear, step-by-step instructions on how the reviewer can test this change locally.
1. Start the server.
2. Run the endpoint: `[Endpoint URL]` with `[Method]` and `[Payload]`.
3. Verify `[Expected Result]`.

### 🔗 Related Issues
Closes #[issue-number]