### PR TITLE
feat(realtime): implement websocket endpoint and redis subscriber

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,7 @@ services:
     environment:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - FRONTEND_URL=http://localhost:5173
     depends_on:
       - redis
     networks:

--- a/services/core-api/projects/admin.py
+++ b/services/core-api/projects/admin.py
@@ -1,3 +1,10 @@
 from django.contrib import admin
-
+from .models import Project
 # Register your models here.
+
+
+@admin.register(Project)
+class ProjectAdmin(admin.ModelAdmin):
+    list_display = ('id', 'name', 'owner', 'created_at')
+    search_fields = ('name', 'description')
+    list_filter = ('created_at',)

--- a/services/realtime-api/ main.py
+++ b/services/realtime-api/ main.py
@@ -1,1 +1,95 @@
 # manage.py 
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.middleware.cors import CORSMiddleware
+import redis.asyncio as redis  # Use the async redis client
+import json
+import os
+import asyncio
+
+app = FastAPI(title="Nexus Real-Time Service")
+
+# 1. CORS Configuration (Allow Frontend to communicate with Backend)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # In production, replace with specific frontend URL
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# 2. Redis Configuration
+# Retrieve connection details from environment variables
+REDIS_URL = f"redis://{os.getenv('REDIS_HOST', 'redis')}:{os.getenv('REDIS_PORT', 6379)}"
+
+
+class ConnectionManager:
+    """
+    Connection Manager: Handles storing all currently connected WebSocket clients.
+    """
+
+    def __init__(self):
+        self.active_connections: list[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket):
+        await websocket.accept()
+        self.active_connections.append(websocket)
+        print(f"🔌 New Client Connected. Total: {len(self.active_connections)}")
+
+    def disconnect(self, websocket: WebSocket):
+        self.active_connections.remove(websocket)
+        print(f"🔌 Client Disconnected. Total: {len(self.active_connections)}")
+
+    async def broadcast(self, message: str):
+        """Broadcast a message to all connected clients."""
+        for connection in self.active_connections:
+            try:
+                await connection.send_text(message)
+            except Exception as e:
+                print(f"❌ Error sending message: {e}")
+
+
+manager = ConnectionManager()
+
+
+# 3. Redis Listener Function (Runs in the background)
+async def redis_listener():
+    """
+    Acts as a permanent 'radar'.
+    Listens to the Redis channel 'events:projects' and distributes messages
+    to all connected WebSocket clients.
+    """
+    print("🎧 Redis Listener Started...")
+    try:
+        # Establish async connection to Redis
+        r = redis.from_url(REDIS_URL, encoding="utf-8", decode_responses=True)
+        async with r.pubsub() as pubsub:
+            await pubsub.subscribe("events:projects")
+
+            async for message in pubsub.listen():
+                if message["type"] == "message":
+                    data = message["data"]
+                    print(f"📨 Received from Redis: {data}")
+                    # Send the message immediately to the frontend
+                    await manager.broadcast(data)
+    except Exception as e:
+        print(f"❌ Redis Connection Error: {e}")
+
+
+# 4. Start the listener on application startup
+@app.on_event("startup")
+async def startup_event():
+    # Run the listener as a background task
+    asyncio.create_task(redis_listener())
+
+
+# 5. Main WebSocket Endpoint
+@app.websocket("/ws/projects")
+async def websocket_endpoint(websocket: WebSocket):
+    await manager.connect(websocket)
+    try:
+        while True:
+            # Keep the connection open (Heartbeat)
+            # This waits for messages from the client, keeping the socket alive
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)


### PR DESCRIPTION
This commit finalizes the "Listener" side of the Real-Time Event System (Milestone v0.3). The FastAPI service now acts as a bridge between the Redis message broker and the frontend clients, enabling instant updates without polling.

Key Changes:
- ⚡ Realtime Service (FastAPI):
  - Refactored `services/realtime-api/main.py` to support WebSockets.
  - Implemented `ConnectionManager` class to handle active client connections and broadcasting.
  - Added `redis_listener` async background task to subscribe to the `events:projects` channel.
  - Exposed `/ws/projects` WebSocket endpoint for frontend clients.
  - Configured CORS middleware to allow external connections (currently set to '*').

- 🔄 Workflow:
  1. Django publishes an event to Redis.
  2. FastAPI listener captures the event.
  3. FastAPI broadcasts the payload to all connected WebSockets.

-------------------------------------------------- 🧪 Manual Test Plan
--------------------------------------------------

1. Restart the Service: $ docker-compose restart realtime-api

2. Connect a WebSocket Client:
   - Open a tool like Hoppscotch (Realtime) or Postman.
   - Connect to: ws://localhost:8002/ws/projects
   - Status should change to "Connected".

3. Trigger an Event:
   - Create a new project via Django Admin (http://localhost:8000/admin/).

4. Verify Reception:
   - The WebSocket client should immediately receive a JSON payload: { "type": "PROJECT_CREATED", "data": { "id": 1, "name": "Test Project", ... } }

## Pull Request Title: [FEAT/FIX/CHORE]: Concise description of changes

### ⚙️ Type of Change
- [x] Feature (New capability)
- [x] Fix (Bug correction)
- [x] Refactor (Code structure improvement without changing behavior)
- [x] Chore (Dependencies, docs, CI/CD, etc.)

### 🎯 Description
A detailed explanation of the changes made and why they are necessary.

### 🧪 Testing Steps
Provide clear, step-by-step instructions on how the reviewer can test this change locally.
1. Start the server.
2. Run the endpoint: `[Endpoint URL]` with `[Method]` and `[Payload]`.
3. Verify `[Expected Result]`.

### 🔗 Related Issues
Closes #[issue-number]